### PR TITLE
fix: add nonce to stylesheet and modulepreload links

### DIFF
--- a/server/Pages/_Host.cshtml
+++ b/server/Pages/_Host.cshtml
@@ -36,6 +36,7 @@
     // link rel="stylesheet"
     var nonceLinkStyle = $"<link nonce=\"{nonce}\" rel=\"stylesheet";
     source = source.Replace("<link rel=\"stylesheet", nonceLinkStyle);
+    source = source.Replace("<link rel=\"modulepreload", nonceLinkStyle);
 
     var xsrf = antiForgery.GetAndStoreTokens(HttpContext);
     var requestToken = xsrf.RequestToken;


### PR DESCRIPTION
👋 @damienbod , I used this example for a project (thanks for it!) and noticed it had a missing replacement for the nonce. Angular uses this to preload lazy loaded chunks.